### PR TITLE
Add Cortex deployment tracker

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,7 @@ jobs:
     uses: workleap/wl-reusable-workflows/.github/workflows/linearb-deployment.yml@main
     with:
       environment: 'release'
+      cortexEntityIdOrTag: service-wl-extensions-mediatr
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
Jira issue link: [feng-722](https://workleap.atlassian.net/browse/feng-722)

This pull request updates the `.github/workflows/publish.yml` file to include a new configuration for deployment. The most notable change is the addition of the `cortexEntityIdOrTag` parameter to the reusable workflow.

### Workflow configuration updates:

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R48): Added the `cortexEntityIdOrTag` parameter with the value `service-wl-extensions-mediatr` to the `jobs:` section, enabling tagging or identification of the deployment entity in the workflow.