### PR TITLE
Update MediatR license handling and project configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,37 @@ builder.Services.AddMediator(
     typeof(Program).Assembly);
 ```
 
+## MediatR License Configuration
+
+This library automatically handles MediatR license configuration. The license key can be provided through:
+
+1. **Environment variable**: Set the `MEDIATR_LICENSE_KEY` environment variable
+2. **Application configuration**: Add the `MEDIATR_LICENSE_KEY` key to your configuration (e.g., appsettings.json, user secrets, etc.)
+
+### Using environment variable
+
+```bash
+# Set environment variable
+export MEDIATR_LICENSE_KEY="your-license-key-here"
+```
+
+### Using appsettings.json
+
+```json
+{
+  "MEDIATR_LICENSE_KEY": "your-license-key-here"
+}
+```
+
+### Manual configuration
+
+You can also set the license key manually using the configuration overload:
+
+```csharp
+builder.Services.AddMediator(
+    cfg => cfg.LicenseKey = "your-license-key-here",
+    typeof(Program).Assembly);
+```
 
 ## Example
 

--- a/src/Workleap.Extensions.MediatR.ApplicationInsights/Workleap.Extensions.MediatR.ApplicationInsights.csproj
+++ b/src/Workleap.Extensions.MediatR.ApplicationInsights/Workleap.Extensions.MediatR.ApplicationInsights.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.8" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Workleap.Extensions.MediatR.Tests/HostBuilderTests.cs
+++ b/src/Workleap.Extensions.MediatR.Tests/HostBuilderTests.cs
@@ -1,0 +1,37 @@
+using System.Diagnostics;
+using MediatR;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Workleap.Extensions.MediatR.Tests;
+public sealed class HostBuilderTests
+{
+    [Fact]
+    public async Task SetLicenseFromConfiguration()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Services.AddMediator(typeof(HostBuilderTests).Assembly);
+        builder.Configuration.AddInMemoryCollection([KeyValuePair.Create<string, string?>("MEDIATR_LICENSE_KEY", "License")]);
+
+        // The license is check in the constructor of the Mediator.
+        // We want to ensure that the license is set before the Mediator is created.
+        // This is done by using a custom Mediator that throws an exception in the constructor.
+        builder.Services.AddSingleton<IMediator, CustomMediator>();
+        builder.Services.AddSingleton<Mediator, CustomMediator>();
+
+        await using var app = builder.Build();
+        var task = app.RunAsync();
+
+        var configuration = app.Services.GetRequiredService<MediatRServiceConfiguration>();
+        Assert.Equal("License", configuration.LicenseKey);
+    }
+
+    private sealed class CustomMediator : Mediator
+    {
+        public CustomMediator(IServiceProvider serviceProvider, INotificationPublisher publisher) : base(serviceProvider, publisher)
+        {
+            throw new UnreachableException();
+        }
+    }
+}

--- a/src/Workleap.Extensions.MediatR.Tests/Workleap.Extensions.MediatR.Tests.csproj
+++ b/src/Workleap.Extensions.MediatR.Tests/Workleap.Extensions.MediatR.Tests.csproj
@@ -8,6 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+
     <ProjectReference Include="..\Workleap.Extensions.MediatR.Analyzers\Workleap.Extensions.MediatR.Analyzers.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\Workleap.Extensions.MediatR.ApplicationInsights\Workleap.Extensions.MediatR.ApplicationInsights.csproj" />
     <ProjectReference Include="..\Workleap.Extensions.MediatR\Workleap.Extensions.MediatR.csproj" />

--- a/src/Workleap.Extensions.MediatR/Workleap.Extensions.MediatR.csproj
+++ b/src/Workleap.Extensions.MediatR/Workleap.Extensions.MediatR.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
@@ -12,18 +12,21 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MediatR" Version="12.5.0" />
+    <PackageReference Include="MediatR" Version="13.0.0" />
     <PackageReference Include="MediatR.Contracts" Version="2.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.3.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />
+    <PackageReference Include="System.Text.Json" Version="9.0.8" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="9.0.8" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Enhanced README.md with MediatR license configuration details.
- Updated `Microsoft.Bcl.AsyncInterfaces` package to version 9.0.8.
- Changed project SDK for Workleap.Extensions.MediatR.Tests to Microsoft.NET.Sdk.Web.
- Modified MediatorBuilder to include a singleton `IStartupFilter` for license key management.
- Default configuration now retrieves the license key from environment variables.
- Added `LicenseProvider` class for startup filter logic.
- Upgraded MediatR package version to 13.0.0 and added new package references.
- Introduced `HostBuilderTests` to validate license key configuration.
- Created launchSettings.json for development environment setup.

<!-- Please fill out any relevant sections and remove those that don't apply -->

## Description of changes
<!-- What was changed in this pull request? -->

## Breaking changes
<!-- What breaking changes were added (if any) and how are they addressed? -->

## Additional checks
<!-- Please check what applies. Note that some of these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Updated the documentation of the project to reflect the changes
- [ ] Added new tests that cover the code changes
